### PR TITLE
fix eslintrc for ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@
 3. Create `.eslintrc.json` file with:
 ```json
 {
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": "latest"
+    },
+    "env": {
+        "es6": true
+    },
     "plugins": [
         "snakecasejs"
     ],


### PR DESCRIPTION
fix these errors

```
error  Parsing error: The keyword 'const' is reserved
error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'
```
